### PR TITLE
ffi package installation fails on macos

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./bin/Z3.js",
   "dependencies": {
     "eslint": "^5.16.0",
-    "ffi": "*",
+    "ffi-napi": "*",
     "node-gyp": "*",
     "ref": "*",
     "ref-array": "*"
@@ -19,7 +19,7 @@
     "prepublish": "./scripts/setup",
     "postinstall": "./scripts/postinstall",
     "build": "./scripts/postinstall; ./scripts/setup",
-    "test": "Z3_PATH=./bin/libz3.so ./test"
+    "test": "Z3_PATH=./bin/libz3.dylib ./test"
   },
   "repository": {
     "type": "git",

--- a/templates/post_ref_bindings.js
+++ b/templates/post_ref_bindings.js
@@ -1,3 +1,4 @@
+var ffi = require('ffi-napi');
 var Z3 = ffi.Library(libPath, GeneratedBindings);
 
 /**

--- a/templates/pre_ref_bindings.js
+++ b/templates/pre_ref_bindings.js
@@ -7,7 +7,6 @@
 // only the function bindings are, not the types
 var ref = require('ref');
 var ArrayType = require('ref-array');
-var ffi = require('ffi');
 
 module.exports = function(libPath) {
 


### PR DESCRIPTION
Hi,

I've reported the package installation failure here: https://github.com/node-ffi/node-ffi/issues/620

However, it seems that `node-ffi` is unmaintained: https://github.com/node-ffi/node-ffi/issues/607

The successor `node-ffi-napi` installs fine for me and supports mostly the same API according to the docs, so we can maybe just use that?